### PR TITLE
Add note about --set-upstream, add wireframes (#1)

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -43,6 +43,10 @@ To switch to an already-made branch, use:
 $ git checkout branch_name
 ```
 
+If you create a new branch, the first time you `push`, you also have to `--set-upstream` (or use the `-u` flag):
+```
+$ git push -u origin branch_name
+```
 
 #### Naming Branches
 Not a huge deal for now, but it would be nice to label branches appropriately.

--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ This project is mainly an excuse to review and practice concepts covered in clas
     - User clicks on a button, which will bring them to a "compose post" page (like any other apps of this kind)
 - A post consists of a subject line and the main content (all text only for now)
 
-That's it for now, but a wireframe could be helpful.
+For a basic wireframe, check out [wireframes.pdf](https://github.com/jtanadi/cork/blob/master/wireframes.pdf)
 
 ## Contributing
 Contributing guidelines [can be found here](https://github.com/jtanadi/cork/blob/master/contributing.md)


### PR DESCRIPTION
Aligning both `dev` and `master` so documentation is available to both branches